### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/common/src/protocol.rs
+++ b/common/src/protocol.rs
@@ -156,7 +156,7 @@ impl fmt::Debug for HttpData {
             } => {
                 write!(
                 f,
-                "Request {{ method: {:?}, url: {:?}, headers: {:?}, body: {:2.?} kB, version: {:?} }}",
+                "Request {{ method: {:?}, url: {:?}, headers: {:?}, body: {:2?} kB, version: {:?} }}",
                 method, url, headers, body.len() as f32 / 1024.0, version
             )
             }
@@ -166,7 +166,7 @@ impl fmt::Debug for HttpData {
                 body,
             } => write!(
                 f,
-                "Response {{ status: {:?}, headers: {:?}, body: {:2.?} kB }}",
+                "Response {{ status: {:?}, headers: {:?}, body: {:2?} kB }}",
                 status,
                 headers,
                 body.len() as f32 / 1024.0


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.